### PR TITLE
Tietoa Sitran ketterästä verkkosivuston hankinnasta

### DIFF
--- a/doc/kirjoituksia_aiheesta.md
+++ b/doc/kirjoituksia_aiheesta.md
@@ -6,8 +6,6 @@
 
 ## Tietoa Sitran ketterästä verkkosivuston hankinnasta
 
-[Yhteiskehittelyn käytäntöä (Sitra.fi)](http://www.sitra.fi/artikkelit/2012/yhteiskehittelyn-kaytantoa-sitrafi)
-
-[Vieraskynä: Sitra tavoittelee avointa ja ketterää verkkoprojektia](http://vierityspalkki.fi/2010/02/26/vieraskyna-sitra-tavoittelee-avointa-ja-ketteraa-verkkoprojektia/)
-
-[Vieraskynä: Julkinen sektorikin voi ostaa ketterästi](http://vierityspalkki.fi/2010/12/07/julkinen-sektorikin-voi-ostaa-ketterasti/)
+* [Yhteiskehittelyn käytäntöä (Sitra.fi)](http://www.sitra.fi/artikkelit/2012/yhteiskehittelyn-kaytantoa-sitrafi)
+* [Vieraskynä: Sitra tavoittelee avointa ja ketterää verkkoprojektia](http://vierityspalkki.fi/2010/02/26/vieraskyna-sitra-tavoittelee-avointa-ja-ketteraa-verkkoprojektia/)
+* [Vieraskynä: Julkinen sektorikin voi ostaa ketterästi](http://vierityspalkki.fi/2010/12/07/julkinen-sektorikin-voi-ostaa-ketterasti/)

--- a/doc/kirjoituksia_aiheesta.md
+++ b/doc/kirjoituksia_aiheesta.md
@@ -7,5 +7,7 @@
 ## Tietoa Sitran ketterästä verkkosivuston hankinnasta
 
 [Yhteiskehittelyn käytäntöä (Sitra.fi)](http://www.sitra.fi/artikkelit/2012/yhteiskehittelyn-kaytantoa-sitrafi)
+
 [Vieraskynä: Sitra tavoittelee avointa ja ketterää verkkoprojektia](http://vierityspalkki.fi/2010/02/26/vieraskyna-sitra-tavoittelee-avointa-ja-ketteraa-verkkoprojektia/)
+
 [Vieraskynä: Julkinen sektorikin voi ostaa ketterästi](http://vierityspalkki.fi/2010/12/07/julkinen-sektorikin-voi-ostaa-ketterasti/)

--- a/doc/kirjoituksia_aiheesta.md
+++ b/doc/kirjoituksia_aiheesta.md
@@ -1,4 +1,11 @@
+# Kirjoituksia aiheesta
 
 [Potilastietojärjestelmähankkeen kustannusten mittakaava - informaatiomuotoilu.fi](http://informaatiomuotoilu.fi/2012/09/potilastietojarjestelmahankkeen-kustannusten-mittakaava/)
 
 [Sitran potilastietojärjestelmäselvityksen loppuraportin yhteenveto](http://www.sitra.fi/NR/rdonlyres/EC4CA5AD-634B-4F80-8ACC-6E70FFAEAFFF/0/Sirius_Potilastietoj%C3%A4rjestelm%C3%A4kartoitus_tiivistelm%C3%A4.pdf)
+
+## Tietoa Sitran ketterästä verkkosivuston hankinnasta
+
+[Yhteiskehittelyn käytäntöä (Sitra.fi)](http://www.sitra.fi/artikkelit/2012/yhteiskehittelyn-kaytantoa-sitrafi)
+[Vieraskynä: Sitra tavoittelee avointa ja ketterää verkkoprojektia](http://vierityspalkki.fi/2010/02/26/vieraskyna-sitra-tavoittelee-avointa-ja-ketteraa-verkkoprojektia/)
+[Vieraskynä: Julkinen sektorikin voi ostaa ketterästi](http://vierityspalkki.fi/2010/12/07/julkinen-sektorikin-voi-ostaa-ketterasti/)

--- a/doc/kirjoituksia_aiheesta.md
+++ b/doc/kirjoituksia_aiheesta.md
@@ -6,6 +6,6 @@
 
 ## Tietoa Sitran ketterästä verkkosivuston hankinnasta
 
-* [Yhteiskehittelyn käytäntöä (Sitra.fi)](http://www.sitra.fi/artikkelit/2012/yhteiskehittelyn-kaytantoa-sitrafi)
-* [Vieraskynä: Sitra tavoittelee avointa ja ketterää verkkoprojektia](http://vierityspalkki.fi/2010/02/26/vieraskyna-sitra-tavoittelee-avointa-ja-ketteraa-verkkoprojektia/)
-* [Vieraskynä: Julkinen sektorikin voi ostaa ketterästi](http://vierityspalkki.fi/2010/12/07/julkinen-sektorikin-voi-ostaa-ketterasti/)
+* Sitra.fi: [Yhteiskehittelyn käytäntöä (Sitra.fi)](http://www.sitra.fi/artikkelit/2012/yhteiskehittelyn-kaytantoa-sitrafi)
+* Vierityspalkki: [Vieraskynä: Sitra tavoittelee avointa ja ketterää verkkoprojektia](http://vierityspalkki.fi/2010/02/26/vieraskyna-sitra-tavoittelee-avointa-ja-ketteraa-verkkoprojektia/)
+* Vierityspalkki: [Vieraskynä: Julkinen sektorikin voi ostaa ketterästi](http://vierityspalkki.fi/2010/12/07/julkinen-sektorikin-voi-ostaa-ketterasti/)

--- a/doc/kirjoituksia_aiheesta.md
+++ b/doc/kirjoituksia_aiheesta.md
@@ -6,6 +6,6 @@
 
 ## Tietoa Sitran ketterästä verkkosivuston hankinnasta
 
-* Sitra.fi: [Yhteiskehittelyn käytäntöä (Sitra.fi)](http://www.sitra.fi/artikkelit/2012/yhteiskehittelyn-kaytantoa-sitrafi)
-* Vierityspalkki: [Vieraskynä: Sitra tavoittelee avointa ja ketterää verkkoprojektia](http://vierityspalkki.fi/2010/02/26/vieraskyna-sitra-tavoittelee-avointa-ja-ketteraa-verkkoprojektia/)
-* Vierityspalkki: [Vieraskynä: Julkinen sektorikin voi ostaa ketterästi](http://vierityspalkki.fi/2010/12/07/julkinen-sektorikin-voi-ostaa-ketterasti/)
+* [Yhteiskehittelyn käytäntöä](http://www.sitra.fi/artikkelit/2012/yhteiskehittelyn-kaytantoa-sitrafi) (Sitra.fi)
+* [Vieraskynä: Sitra tavoittelee avointa ja ketterää verkkoprojektia](http://vierityspalkki.fi/2010/02/26/vieraskyna-sitra-tavoittelee-avointa-ja-ketteraa-verkkoprojektia/) (Vierityspalkki)
+* [Vieraskynä: Julkinen sektorikin voi ostaa ketterästi](http://vierityspalkki.fi/2010/12/07/julkinen-sektorikin-voi-ostaa-ketterasti/) (Vierityspalkki)


### PR DESCRIPTION
Lisätty otsikko sekä aliotsikko "Tietoa Sitran ketterästä verkkosivuston hankinnasta" sekä kolme linkkiä.
